### PR TITLE
Bump clients for API update fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,16 +24,12 @@ build:
 .PHONY: debug
 debug:
 	go build -tags 'debug' $(LDFLAGS) -o $(BINPATH)/dp-interactives-importer
-	HUMAN_LOG=1 DEBUG=1 AWS_ENDPOINT=http://localhost:4566 $(BINPATH)/dp-interactives-importer
+	HUMAN_LOG=1 DEBUG=1 $(BINPATH)/dp-interactives-importer
 
 .PHONY: test
 test:
 	go test -race -cover ./...
 
-.PHONY: test-component
-test-component:
-	echo "TODO"
-	
 .PHONY: convey
 convey:
 	goconvey ./...

--- a/config/config.go
+++ b/config/config.go
@@ -9,7 +9,7 @@ import (
 type Config struct {
 	BindAddr                   string        `envconfig:"BIND_ADDR"`
 	APIRouterURL               string        `envconfig:"API_ROUTER_URL"`
-	ServiceAuthToken           string        `envconfig:"SERVICE_AUTH_TOKEN"`
+	ServiceAuthToken           string        `envconfig:"SERVICE_AUTH_TOKEN" json:"-"`
 	AwsEndpoint                string        `envconfig:"AWS_ENDPOINT"`
 	AwsRegion                  string        `envconfig:"AWS_REGION"`
 	DownloadBucketName         string        `envconfig:"DOWNLOAD_BUCKET_NAME"`
@@ -19,7 +19,7 @@ type Config struct {
 	KafkaSecProtocol           string        `envconfig:"KAFKA_SEC_PROTO"`
 	KafkaSecCACerts            string        `envconfig:"KAFKA_SEC_CA_CERTS"`
 	KafkaSecClientCert         string        `envconfig:"KAFKA_SEC_CLIENT_CERT"`
-	KafkaSecClientKey          string        `envconfig:"KAFKA_SEC_CLIENT_KEY"             json:"-"`
+	KafkaSecClientKey          string        `envconfig:"KAFKA_SEC_CLIENT_KEY" json:"-"`
 	KafkaSecSkipVerify         bool          `envconfig:"KAFKA_SEC_SKIP_VERIFY"`
 	InteractivesReadTopic      string        `envconfig:"INTERACTIVES_READ_TOPIC"`
 	InteractivesGroup          string        `envconfig:"INTERACTIVES_GROUP"`
@@ -37,10 +37,10 @@ func Get() (*Config, error) {
 	}
 
 	cfg = &Config{
-		BindAddr:                   "localhost:27400",
+		BindAddr:                   ":27400",
 		APIRouterURL:               "http://localhost:23200/v1",
 		AwsRegion:                  "eu-west-1",
-		DownloadBucketName:         "dp-interactives-file-uploads",
+		DownloadBucketName:         "testing",
 		Brokers:                    []string{"localhost:9092"},
 		KafkaVersion:               "1.0.2",
 		KafkaMaxBytes:              2000000,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,7 +18,7 @@ func TestConfig(t *testing.T) {
 			})
 
 			Convey("Then the values should be set to the expected defaults", func() {
-				So(cfg.BindAddr, ShouldEqual, "localhost:27400")
+				So(cfg.BindAddr, ShouldEqual, ":27400")
 				So(cfg.Brokers, ShouldResemble, []string{"localhost:9092"})
 				So(cfg.KafkaVersion, ShouldEqual, "1.0.2")
 				So(cfg.KafkaSecProtocol, ShouldEqual, "")

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
 replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.1-0.20210802184156-9742bd7fca1c+incompatible
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.96.9
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.100.1
 	github.com/ONSdigital/dp-component-test v0.6.4
 	github.com/ONSdigital/dp-healthcheck v1.2.3
 	github.com/ONSdigital/dp-kafka/v2 v2.4.4

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.96.9 h1:CHgugduUi/+zp1kvfGIxYurgl3i7nQeBMB/1loVfyLA=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.96.9/go.mod h1:P3GYyqqXnbp4RjWhz0oYpUFjHPT6Ca4fEoh4huNkxHU=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.100.1 h1:Ya/hzUnmM9o0f2luCsm9ymTrmdLIjn952R741MkUR1w=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.100.1/go.mod h1:/Pa0nFxsXQVkMz8ywCfx0dIa6OPbHRup7JRHsb6gBCU=
 github.com/ONSdigital/dp-component-test v0.6.4 h1:zaEm1nkOSabyh5bSxsN7qt9F7FKj199HHvTKOElszlY=
 github.com/ONSdigital/dp-component-test v0.6.4/go.mod h1:Jg4qZJf+cW+L/BvdzDphruMgB8QEHg2YK4WH9jVJh44=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=

--- a/internal/client/uploadservice/uploadservice.go
+++ b/internal/client/uploadservice/uploadservice.go
@@ -62,6 +62,7 @@ func (e ErrInvalidAPIResponse) Code() int {
 var _ error = ErrInvalidAPIResponse{}
 
 type UploadJob struct {
+	Path                 string
 	ResumableFilename    string
 	IsPublishable        bool
 	CollectionId         string
@@ -127,6 +128,7 @@ func (c *Client) doPostForm(ctx context.Context, serviceToken, uri string, job U
 
 	payload := &bytes.Buffer{}
 	writer := multipart.NewWriter(payload)
+	_ = writer.WriteField("path", job.Path)
 	_ = writer.WriteField("resumableFilename", job.ResumableFilename)
 	_ = writer.WriteField("isPublishable", fmt.Sprintf("%v", job.IsPublishable))
 	_ = writer.WriteField("collectionId", job.CollectionId)
@@ -137,6 +139,7 @@ func (c *Client) doPostForm(ctx context.Context, serviceToken, uri string, job U
 	_ = writer.WriteField("licenceUrl", job.LicenceUrl)
 	_ = writer.WriteField("resumableChunkNumber", fmt.Sprintf("%d", job.ResumableChunkNumber))
 	_ = writer.WriteField("resumableTotalChunks", fmt.Sprintf("%d", job.ResumableTotalChunks))
+
 	f, err := os.Open(job.File.Name())
 	defer f.Close()
 	fileWriter, err := writer.CreateFormFile("file", job.File.Name())

--- a/main.go
+++ b/main.go
@@ -42,6 +42,8 @@ func run(ctx context.Context) error {
 		return errors.Wrap(err, "unable to retrieve service configuration")
 	}
 
+	log.Info(ctx, "configuration loaded", log.Data{"config": cfg})
+
 	// Run the service, providing an error channel for fatal errors
 	svcErrors := make(chan error, 1)
 	svcList := service.NewServiceList(&service.Init{})


### PR DESCRIPTION
Bug
- bump api clients so correct api request for update

Housekeeping
- some dp-upload-service changes - currently disabled though
- make file - drop dup target and env var not needed here
