### PR TITLE
Use new PATCH endpoint for updating API after processing archive

### DIFF
--- a/features/steps/component.go
+++ b/features/steps/component.go
@@ -101,8 +101,8 @@ func NewInteractivesImporterComponent() (*Component, error) {
 	}
 
 	c.InteractivesAPI = &mocks_importer.InteractivesAPIClientMock{
-		PutInteractiveFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, interactiveID string, metadata interactives.InteractiveUpdate) error {
-			return nil
+		PatchInteractiveFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, interactiveID string, req interactives.PatchRequest) (interactives.Interactive, error) {
+			return interactives.Interactive{}, nil
 		},
 	}
 

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -100,7 +100,7 @@ func (c *Component) interactiveShouldBeSuccessfullyUpdatedViaTheInteractivesAPI(
 	firstCall := c.InteractivesAPI.PatchInteractiveCalls()[0]
 	assert.Equal(&c.ErrorFeature, id, firstCall.S3)
 	assert.Equal(&c.ErrorFeature, id, firstCall.PatchRequest.Interactive.ID)
-	assert.True(&c.ErrorFeature, firstCall.PatchRequest.Successful)
+	assert.True(&c.ErrorFeature, firstCall.PatchRequest.Interactive.Archive.ImportSuccessful)
 	return c.ErrorFeature.StepError()
 }
 
@@ -109,7 +109,7 @@ func (c *Component) interactiveShouldBeUpdatedAsAFailureViaTheInteractivesAPI(id
 	firstCall := c.InteractivesAPI.PatchInteractiveCalls()[0]
 	assert.Equal(&c.ErrorFeature, id, firstCall.S3)
 	assert.Equal(&c.ErrorFeature, id, firstCall.PatchRequest.Interactive.ID)
-	assert.NotEmpty(&c.ErrorFeature, firstCall.PatchRequest.Message)
-	assert.False(&c.ErrorFeature, firstCall.PatchRequest.Successful)
+	assert.NotEmpty(&c.ErrorFeature, firstCall.PatchRequest.Interactive.Archive.ImportMessage)
+	assert.False(&c.ErrorFeature, firstCall.PatchRequest.Interactive.Archive.ImportSuccessful)
 	return c.ErrorFeature.StepError()
 }

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -96,20 +96,20 @@ func (c *Component) interactivesShouldBeUploadedViaTheUploadService(count int) e
 }
 
 func (c *Component) interactiveShouldBeSuccessfullyUpdatedViaTheInteractivesAPI(id string) error {
-	assert.Equal(&c.ErrorFeature, 1, len(c.InteractivesAPI.PutInteractiveCalls()))
-	firstCall := c.InteractivesAPI.PutInteractiveCalls()[0]
-	assert.Equal(&c.ErrorFeature, id, firstCall.InteractiveID)
-	assert.Equal(&c.ErrorFeature, id, firstCall.Update.Interactive.ID)
-	assert.True(&c.ErrorFeature, *firstCall.Update.ImportSuccessful)
+	assert.Equal(&c.ErrorFeature, 1, len(c.InteractivesAPI.PatchInteractiveCalls()))
+	firstCall := c.InteractivesAPI.PatchInteractiveCalls()[0]
+	assert.Equal(&c.ErrorFeature, id, firstCall.S3)
+	assert.Equal(&c.ErrorFeature, id, firstCall.PatchRequest.Interactive.ID)
+	assert.True(&c.ErrorFeature, firstCall.PatchRequest.Successful)
 	return c.ErrorFeature.StepError()
 }
 
 func (c *Component) interactiveShouldBeUpdatedAsAFailureViaTheInteractivesAPI(id string) error {
-	assert.Equal(&c.ErrorFeature, 1, len(c.InteractivesAPI.PutInteractiveCalls()))
-	firstCall := c.InteractivesAPI.PutInteractiveCalls()[0]
-	assert.Equal(&c.ErrorFeature, id, firstCall.InteractiveID)
-	assert.Equal(&c.ErrorFeature, id, firstCall.Update.Interactive.ID)
-	assert.NotEmpty(&c.ErrorFeature, firstCall.Update.ImportMessage)
-	assert.False(&c.ErrorFeature, *firstCall.Update.ImportSuccessful)
+	assert.Equal(&c.ErrorFeature, 1, len(c.InteractivesAPI.PatchInteractiveCalls()))
+	firstCall := c.InteractivesAPI.PatchInteractiveCalls()[0]
+	assert.Equal(&c.ErrorFeature, id, firstCall.S3)
+	assert.Equal(&c.ErrorFeature, id, firstCall.PatchRequest.Interactive.ID)
+	assert.NotEmpty(&c.ErrorFeature, firstCall.PatchRequest.Message)
+	assert.False(&c.ErrorFeature, firstCall.PatchRequest.Successful)
 	return c.ErrorFeature.StepError()
 }

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,8 @@ replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
 
 replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.1-0.20210802184156-9742bd7fca1c+incompatible
 
-replace github.com/ONSdigital/dp-api-clients-go/v2 => /Users/markryan/workspace/methods/ons/dp-api-clients-go
-
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.116.1
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.128.0
 	github.com/ONSdigital/dp-component-test v0.6.4
 	github.com/ONSdigital/dp-healthcheck v1.2.3
 	github.com/ONSdigital/dp-kafka/v3 v3.3.2

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ replace github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
 
 replace github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go v3.2.1-0.20210802184156-9742bd7fca1c+incompatible
 
+replace github.com/ONSdigital/dp-api-clients-go/v2 => /Users/markryan/workspace/methods/ons/dp-api-clients-go
+
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.116.1
 	github.com/ONSdigital/dp-component-test v0.6.4

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,6 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.116.1 h1:ul8IlIOHsy70DoSHntvS++Hfs6AH6ICrklupo5Wa77s=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.116.1/go.mod h1:tHRq65gA340CYpkHIRMrrxiLS8IlAl7nTeFr07ukJgo=
 github.com/ONSdigital/dp-component-test v0.6.4 h1:zaEm1nkOSabyh5bSxsN7qt9F7FKj199HHvTKOElszlY=
 github.com/ONSdigital/dp-component-test v0.6.4/go.mod h1:Jg4qZJf+cW+L/BvdzDphruMgB8QEHg2YK4WH9jVJh44=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.128.0 h1:K+BjQoOD+xBO2Eukxs318eTQi1Ges32zkNMyWTKVl0g=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.128.0/go.mod h1:tHRq65gA340CYpkHIRMrrxiLS8IlAl7nTeFr07ukJgo=
 github.com/ONSdigital/dp-component-test v0.6.4 h1:zaEm1nkOSabyh5bSxsN7qt9F7FKj199HHvTKOElszlY=
 github.com/ONSdigital/dp-component-test v0.6.4/go.mod h1:Jg4qZJf+cW+L/BvdzDphruMgB8QEHg2YK4WH9jVJh44=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=

--- a/importer/handler.go
+++ b/importer/handler.go
@@ -33,7 +33,7 @@ func (h *InteractivesUploadedHandler) Handle(ctx context.Context, workerID int, 
 	// Defer an update via API - deferred so we always attempt an update!
 	defer func() {
 		patchReq := interactives.PatchRequest{
-			Action: interactives.PatchImportArchive,
+			Attribute: interactives.PatchArchive,
 			Interactive: interactives.Interactive{
 				ID: event.ID,
 				Archive: &interactives.InteractiveArchive{
@@ -43,10 +43,9 @@ func (h *InteractivesUploadedHandler) Handle(ctx context.Context, workerID int, 
 		}
 		if err != nil {
 			logData["error"] = err.Error()
-			patchReq.Successful = false
-			patchReq.Message = err.Error()
+			patchReq.Interactive.Archive.ImportMessage = err.Error()
 		} else {
-			patchReq.Successful = true
+			patchReq.Interactive.Archive.ImportSuccessful = true
 			patchReq.Interactive.Archive.Size = *zipSize
 			patchReq.Interactive.Archive.Files = archiveFiles
 		}

--- a/importer/interface.go
+++ b/importer/interface.go
@@ -23,6 +23,6 @@ type UploadServiceBackend interface {
 }
 
 type InteractivesAPIClient interface {
-	PutInteractive(ctx context.Context, userAuthToken, serviceAuthToken, interactiveID string, update interactives.InteractiveUpdate) error
+	PatchInteractive(context.Context, string, string, string, interactives.PatchRequest) (interactives.Interactive, error)
 	Checker(ctx context.Context, state *health.CheckState) error
 }

--- a/importer/mocks/interactives_api.go
+++ b/importer/mocks/interactives_api.go
@@ -24,8 +24,8 @@ var _ importer.InteractivesAPIClient = &InteractivesAPIClientMock{}
 // 			CheckerFunc: func(ctx context.Context, state *health.CheckState) error {
 // 				panic("mock out the Checker method")
 // 			},
-// 			PutInteractiveFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, interactiveID string, update interactives.InteractiveUpdate) error {
-// 				panic("mock out the PutInteractive method")
+// 			PatchInteractiveFunc: func(contextMoqParam context.Context, s1 string, s2 string, s3 string, patchRequest interactives.PatchRequest) (interactives.Interactive, error) {
+// 				panic("mock out the PatchInteractive method")
 // 			},
 // 		}
 //
@@ -37,8 +37,8 @@ type InteractivesAPIClientMock struct {
 	// CheckerFunc mocks the Checker method.
 	CheckerFunc func(ctx context.Context, state *health.CheckState) error
 
-	// PutInteractiveFunc mocks the PutInteractive method.
-	PutInteractiveFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, interactiveID string, update interactives.InteractiveUpdate) error
+	// PatchInteractiveFunc mocks the PatchInteractive method.
+	PatchInteractiveFunc func(contextMoqParam context.Context, s1 string, s2 string, s3 string, patchRequest interactives.PatchRequest) (interactives.Interactive, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -49,22 +49,22 @@ type InteractivesAPIClientMock struct {
 			// State is the state argument value.
 			State *health.CheckState
 		}
-		// PutInteractive holds details about calls to the PutInteractive method.
-		PutInteractive []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// UserAuthToken is the userAuthToken argument value.
-			UserAuthToken string
-			// ServiceAuthToken is the serviceAuthToken argument value.
-			ServiceAuthToken string
-			// InteractiveID is the interactiveID argument value.
-			InteractiveID string
-			// Update is the update argument value.
-			Update interactives.InteractiveUpdate
+		// PatchInteractive holds details about calls to the PatchInteractive method.
+		PatchInteractive []struct {
+			// ContextMoqParam is the contextMoqParam argument value.
+			ContextMoqParam context.Context
+			// S1 is the s1 argument value.
+			S1 string
+			// S2 is the s2 argument value.
+			S2 string
+			// S3 is the s3 argument value.
+			S3 string
+			// PatchRequest is the patchRequest argument value.
+			PatchRequest interactives.PatchRequest
 		}
 	}
-	lockChecker        sync.RWMutex
-	lockPutInteractive sync.RWMutex
+	lockChecker          sync.RWMutex
+	lockPatchInteractive sync.RWMutex
 }
 
 // Checker calls CheckerFunc.
@@ -102,49 +102,49 @@ func (mock *InteractivesAPIClientMock) CheckerCalls() []struct {
 	return calls
 }
 
-// PutInteractive calls PutInteractiveFunc.
-func (mock *InteractivesAPIClientMock) PutInteractive(ctx context.Context, userAuthToken string, serviceAuthToken string, interactiveID string, update interactives.InteractiveUpdate) error {
-	if mock.PutInteractiveFunc == nil {
-		panic("InteractivesAPIClientMock.PutInteractiveFunc: method is nil but InteractivesAPIClient.PutInteractive was just called")
+// PatchInteractive calls PatchInteractiveFunc.
+func (mock *InteractivesAPIClientMock) PatchInteractive(contextMoqParam context.Context, s1 string, s2 string, s3 string, patchRequest interactives.PatchRequest) (interactives.Interactive, error) {
+	if mock.PatchInteractiveFunc == nil {
+		panic("InteractivesAPIClientMock.PatchInteractiveFunc: method is nil but InteractivesAPIClient.PatchInteractive was just called")
 	}
 	callInfo := struct {
-		Ctx              context.Context
-		UserAuthToken    string
-		ServiceAuthToken string
-		InteractiveID    string
-		Update           interactives.InteractiveUpdate
+		ContextMoqParam context.Context
+		S1              string
+		S2              string
+		S3              string
+		PatchRequest    interactives.PatchRequest
 	}{
-		Ctx:              ctx,
-		UserAuthToken:    userAuthToken,
-		ServiceAuthToken: serviceAuthToken,
-		InteractiveID:    interactiveID,
-		Update:           update,
+		ContextMoqParam: contextMoqParam,
+		S1:              s1,
+		S2:              s2,
+		S3:              s3,
+		PatchRequest:    patchRequest,
 	}
-	mock.lockPutInteractive.Lock()
-	mock.calls.PutInteractive = append(mock.calls.PutInteractive, callInfo)
-	mock.lockPutInteractive.Unlock()
-	return mock.PutInteractiveFunc(ctx, userAuthToken, serviceAuthToken, interactiveID, update)
+	mock.lockPatchInteractive.Lock()
+	mock.calls.PatchInteractive = append(mock.calls.PatchInteractive, callInfo)
+	mock.lockPatchInteractive.Unlock()
+	return mock.PatchInteractiveFunc(contextMoqParam, s1, s2, s3, patchRequest)
 }
 
-// PutInteractiveCalls gets all the calls that were made to PutInteractive.
+// PatchInteractiveCalls gets all the calls that were made to PatchInteractive.
 // Check the length with:
-//     len(mockedInteractivesAPIClient.PutInteractiveCalls())
-func (mock *InteractivesAPIClientMock) PutInteractiveCalls() []struct {
-	Ctx              context.Context
-	UserAuthToken    string
-	ServiceAuthToken string
-	InteractiveID    string
-	Update           interactives.InteractiveUpdate
+//     len(mockedInteractivesAPIClient.PatchInteractiveCalls())
+func (mock *InteractivesAPIClientMock) PatchInteractiveCalls() []struct {
+	ContextMoqParam context.Context
+	S1              string
+	S2              string
+	S3              string
+	PatchRequest    interactives.PatchRequest
 } {
 	var calls []struct {
-		Ctx              context.Context
-		UserAuthToken    string
-		ServiceAuthToken string
-		InteractiveID    string
-		Update           interactives.InteractiveUpdate
+		ContextMoqParam context.Context
+		S1              string
+		S2              string
+		S3              string
+		PatchRequest    interactives.PatchRequest
 	}
-	mock.lockPutInteractive.RLock()
-	calls = mock.calls.PutInteractive
-	mock.lockPutInteractive.RUnlock()
+	mock.lockPatchInteractive.RLock()
+	calls = mock.calls.PatchInteractive
+	mock.lockPatchInteractive.RUnlock()
 	return calls
 }

--- a/importer/mocks/s3.go
+++ b/importer/mocks/s3.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-interactives-importer/importer"
-	s3client "github.com/ONSdigital/dp-s3"
 	"io"
 	"sync"
 )
@@ -22,17 +21,11 @@ var _ importer.S3Interface = &S3InterfaceMock{}
 //
 // 		// make and configure a mocked importer.S3Interface
 // 		mockedS3Interface := &S3InterfaceMock{
-// 			CheckPartUploadedFunc: func(ctx context.Context, req *s3client.UploadPartRequest) (bool, error) {
-// 				panic("mock out the CheckPartUploaded method")
-// 			},
 // 			CheckerFunc: func(ctx context.Context, state *health.CheckState) error {
 // 				panic("mock out the Checker method")
 // 			},
 // 			GetFunc: func(key string) (io.ReadCloser, *int64, error) {
 // 				panic("mock out the Get method")
-// 			},
-// 			UploadPartFunc: func(ctx context.Context, req *s3client.UploadPartRequest, payload []byte) error {
-// 				panic("mock out the UploadPart method")
 // 			},
 // 		}
 //
@@ -41,27 +34,14 @@ var _ importer.S3Interface = &S3InterfaceMock{}
 //
 // 	}
 type S3InterfaceMock struct {
-	// CheckPartUploadedFunc mocks the CheckPartUploaded method.
-	CheckPartUploadedFunc func(ctx context.Context, req *s3client.UploadPartRequest) (bool, error)
-
 	// CheckerFunc mocks the Checker method.
 	CheckerFunc func(ctx context.Context, state *health.CheckState) error
 
 	// GetFunc mocks the Get method.
 	GetFunc func(key string) (io.ReadCloser, *int64, error)
 
-	// UploadPartFunc mocks the UploadPart method.
-	UploadPartFunc func(ctx context.Context, req *s3client.UploadPartRequest, payload []byte) error
-
 	// calls tracks calls to the methods.
 	calls struct {
-		// CheckPartUploaded holds details about calls to the CheckPartUploaded method.
-		CheckPartUploaded []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// Req is the req argument value.
-			Req *s3client.UploadPartRequest
-		}
 		// Checker holds details about calls to the Checker method.
 		Checker []struct {
 			// Ctx is the ctx argument value.
@@ -74,55 +54,9 @@ type S3InterfaceMock struct {
 			// Key is the key argument value.
 			Key string
 		}
-		// UploadPart holds details about calls to the UploadPart method.
-		UploadPart []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// Req is the req argument value.
-			Req *s3client.UploadPartRequest
-			// Payload is the payload argument value.
-			Payload []byte
-		}
 	}
-	lockCheckPartUploaded sync.RWMutex
-	lockChecker           sync.RWMutex
-	lockGet               sync.RWMutex
-	lockUploadPart        sync.RWMutex
-}
-
-// CheckPartUploaded calls CheckPartUploadedFunc.
-func (mock *S3InterfaceMock) CheckPartUploaded(ctx context.Context, req *s3client.UploadPartRequest) (bool, error) {
-	if mock.CheckPartUploadedFunc == nil {
-		panic("S3InterfaceMock.CheckPartUploadedFunc: method is nil but S3Interface.CheckPartUploaded was just called")
-	}
-	callInfo := struct {
-		Ctx context.Context
-		Req *s3client.UploadPartRequest
-	}{
-		Ctx: ctx,
-		Req: req,
-	}
-	mock.lockCheckPartUploaded.Lock()
-	mock.calls.CheckPartUploaded = append(mock.calls.CheckPartUploaded, callInfo)
-	mock.lockCheckPartUploaded.Unlock()
-	return mock.CheckPartUploadedFunc(ctx, req)
-}
-
-// CheckPartUploadedCalls gets all the calls that were made to CheckPartUploaded.
-// Check the length with:
-//     len(mockedS3Interface.CheckPartUploadedCalls())
-func (mock *S3InterfaceMock) CheckPartUploadedCalls() []struct {
-	Ctx context.Context
-	Req *s3client.UploadPartRequest
-} {
-	var calls []struct {
-		Ctx context.Context
-		Req *s3client.UploadPartRequest
-	}
-	mock.lockCheckPartUploaded.RLock()
-	calls = mock.calls.CheckPartUploaded
-	mock.lockCheckPartUploaded.RUnlock()
-	return calls
+	lockChecker sync.RWMutex
+	lockGet     sync.RWMutex
 }
 
 // Checker calls CheckerFunc.
@@ -188,44 +122,5 @@ func (mock *S3InterfaceMock) GetCalls() []struct {
 	mock.lockGet.RLock()
 	calls = mock.calls.Get
 	mock.lockGet.RUnlock()
-	return calls
-}
-
-// UploadPart calls UploadPartFunc.
-func (mock *S3InterfaceMock) UploadPart(ctx context.Context, req *s3client.UploadPartRequest, payload []byte) error {
-	if mock.UploadPartFunc == nil {
-		panic("S3InterfaceMock.UploadPartFunc: method is nil but S3Interface.UploadPart was just called")
-	}
-	callInfo := struct {
-		Ctx     context.Context
-		Req     *s3client.UploadPartRequest
-		Payload []byte
-	}{
-		Ctx:     ctx,
-		Req:     req,
-		Payload: payload,
-	}
-	mock.lockUploadPart.Lock()
-	mock.calls.UploadPart = append(mock.calls.UploadPart, callInfo)
-	mock.lockUploadPart.Unlock()
-	return mock.UploadPartFunc(ctx, req, payload)
-}
-
-// UploadPartCalls gets all the calls that were made to UploadPart.
-// Check the length with:
-//     len(mockedS3Interface.UploadPartCalls())
-func (mock *S3InterfaceMock) UploadPartCalls() []struct {
-	Ctx     context.Context
-	Req     *s3client.UploadPartRequest
-	Payload []byte
-} {
-	var calls []struct {
-		Ctx     context.Context
-		Req     *s3client.UploadPartRequest
-		Payload []byte
-	}
-	mock.lockUploadPart.RLock()
-	calls = mock.calls.UploadPart
-	mock.lockUploadPart.RUnlock()
 	return calls
 }


### PR DESCRIPTION
### What

Use new API PATCH endpoint for partial updates - i.e just updating the interactive with files uploaded from importer async task.

Still to be completed a go.mod update coming when merged: https://github.com/ONSdigital/dp-api-clients-go/pull/252

### How to review

Sanity check - code & tests

### Who can review

Anyone
