### PR TITLE
Return OK for dp-upload-service mock checker

### DIFF
--- a/service/initialise.go
+++ b/service/initialise.go
@@ -169,8 +169,8 @@ func (e *Init) DoGetUploadServiceBackend(ctx context.Context, cfg *config.Config
 			UploadFunc: func(context.Context, io.ReadCloser, upload.Metadata) error {
 				return nil
 			},
-			CheckerFunc: func(_ context.Context, _ *healthcheck.CheckState) error {
-				return nil
+			CheckerFunc: func(_ context.Context, state *healthcheck.CheckState) error {
+				return state.Update(healthcheck.StatusOK, "*** MOCK ***", http.StatusOK)
 			},
 		}
 	} else {


### PR DESCRIPTION
Should return OK 🤦 

```
{
  "status": "OK",
  "version": {
    "build_time": "2022-01-19T16:28:14Z",
    "git_commit": "",
    "language": "go",
    "language_version": "go1.17.8",
    "version": ""
  },
  "uptime": 3611,
  "start_time": "2022-06-06T07:59:40.561951Z",
  "checks": [
    {
      "name": "Kafka consumer",
      "status": "OK",
      "message": "kafka consumer group is healthy",
      "last_checked": "2022-06-06T07:59:40.565715Z",
      "last_success": "2022-06-06T07:59:40.565715Z",
      "last_failure": null
    },
    {
      "name": "S3 bucket",
      "status": "OK",
      "message": "S3 is healthy",
      "last_checked": "2022-06-06T07:59:40.584147Z",
      "last_success": "2022-06-06T07:59:40.584147Z",
      "last_failure": null
    },
    {
      "name": "Upload API",
      "status": "OK",
      "status_code": 200,
      "message": "*** MOCK ***",
      "last_checked": "2022-06-06T07:59:40.562013Z",
      "last_success": "2022-06-06T07:59:40.562013Z",
      "last_failure": null
    }
  ]
}
```