### PR TITLE
lift restriction for index.html

### DIFF
--- a/importer/archive.go
+++ b/importer/archive.go
@@ -16,8 +16,7 @@ import (
 )
 
 var (
-	ErrNoIndexHtml          = errors.New("interactive must contain 1 index.html in root folder")
-	ErrMoreThanOneIndexHtml = errors.New("there can only be 1 index.html in an interactive")
+	ErrNoIndexHtml          = errors.New("interactive must contain 1 index.html")
 	fileMatchersToIgnore    = []matcher{
 		//hidden files
 		func(f string) bool { return f[0] == '.' },
@@ -71,13 +70,7 @@ func (a *Archive) OpenAndValidate() error {
 			}
 
 			if strings.EqualFold(filepath.Base(f.Name), "index.html") {
-				if hasIndexHtml {
-					return ErrMoreThanOneIndexHtml
-				}
-				// Check that the above index file is in root
-				if strings.EqualFold(filepath.Clean(f.Name), "index.html") {
-					hasIndexHtml = true
-				}
+				hasIndexHtml = true
 			}
 
 			size := int64(f.UncompressedSize64)

--- a/importer/archive_test.go
+++ b/importer/archive_test.go
@@ -77,22 +77,6 @@ func TestArchive(t *testing.T) {
 		})
 	})
 
-	Convey("Given an invalid zip file (multiple index.html)", t, func() {
-		archiveName, err := test.CreateTestZip("root.css", "root.html", "root.js", "index.html", "test/index.html")
-		defer os.Remove(archiveName)
-		So(err, ShouldBeNil)
-		So(archiveName, ShouldNotBeEmpty)
-
-		Convey("Then open should run successfully", func() {
-			archive, err := os.Open(archiveName)
-			So(err, ShouldBeNil)
-
-			a := &importer.Archive{Context: context.TODO(), ReadCloser: archive}
-			err = a.OpenAndValidate()
-			So(err, ShouldEqual, importer.ErrMoreThanOneIndexHtml)
-		})
-	})
-
 	Convey("Given an actual valid zip file", t, func() {
 		rc, err := validZipFile.Open("test/single-interactive.zip")
 		So(err, ShouldBeNil)
@@ -101,17 +85,6 @@ func TestArchive(t *testing.T) {
 			a := &importer.Archive{Context: context.TODO(), ReadCloser: rc}
 			err = a.OpenAndValidate()
 			So(err, ShouldBeNil)
-		})
-	})
-
-	Convey("Given an actual invalid zip file", t, func() {
-		rc, err := invalidZipFile.Open("test/dvc1774.zip")
-		So(err, ShouldBeNil)
-
-		Convey("Then open should error", func() {
-			a := &importer.Archive{Context: context.TODO(), ReadCloser: rc}
-			err = a.OpenAndValidate()
-			So(err, ShouldEqual, importer.ErrNoIndexHtml)
 		})
 	})
 }


### PR DESCRIPTION
In order to support multiple interactives need to lift restriction for:
1. index.htm to be in the root folder
2. only 1 index.htm file
