### PR TITLE
Revert change where dropped saved filename from upload service

### DIFF
--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -100,6 +101,10 @@ func (c *Component) interactiveShouldBeSuccessfullyUpdatedViaTheInteractivesAPI(
 	firstCall := c.InteractivesAPI.PatchInteractiveCalls()[0]
 	assert.Equal(&c.ErrorFeature, id, firstCall.S3)
 	assert.Equal(&c.ErrorFeature, id, firstCall.PatchRequest.Interactive.ID)
+	assert.Empty(&c.ErrorFeature, firstCall.PatchRequest.Interactive.Archive.Files[0].URI)
+	root, _ := importer.GetPathAndFilename("", id, 1)
+	isFileWithSameRoot := strings.HasPrefix(firstCall.PatchRequest.Interactive.Archive.Files[0].Name, root)
+	assert.True(&c.ErrorFeature, isFileWithSameRoot)
 	assert.True(&c.ErrorFeature, firstCall.PatchRequest.Interactive.Archive.ImportSuccessful)
 	return c.ErrorFeature.StepError()
 }

--- a/importer/handler.go
+++ b/importer/handler.go
@@ -118,19 +118,17 @@ func (h *InteractivesUploadedHandler) Handle(ctx context.Context, workerID int, 
 			MimeType:    mimetype,
 		}
 
+		savedFileName, err := h.UploadService.SendFile(ctx, event, file)
 		fileExt := filepath.Ext(zip.Name)
 		if strings.EqualFold(fileExt, ".html") || strings.EqualFold(fileExt, ".htm") {
 			//for optimisation - i.e. handling super large zips with 300k files only save these
 			//applicable for preview
 			archiveFiles = append(archiveFiles, &interactives.InteractiveFile{
-				Name:     zip.Name,
+				Name:     savedFileName,
 				Size:     size,
-				URI:      zip.Name,
 				Mimetype: mimetype,
 			})
 		}
-
-		_, err = h.UploadService.SendFile(ctx, event, file)
 		return err
 	}
 	err = Process(h.Cfg.BatchSize, tmpZip.Name(), uploadFunc)

--- a/importer/upload.go
+++ b/importer/upload.go
@@ -57,7 +57,7 @@ func (s *UploadService) SendFile(ctx context.Context, event *InteractivesUploade
 
 	var attempts int
 	for {
-		metadata.Path, metadata.FileName = getPathAndFilename(f.Name, event.ID, version)
+		metadata.Path, metadata.FileName = GetPathAndFilename(f.Name, event.ID, version)
 		err := s.backend.Upload(ctx, f.ReadCloser, metadata)
 		if err == nil {
 			break
@@ -78,6 +78,6 @@ func (s *UploadService) SendFile(ctx context.Context, event *InteractivesUploade
 }
 
 //no leading slash: https://github.com/ONSdigital/dp-upload-service/blob/ecc6062e6fe5856385b5fafbe1105606c1a958ff/api/upload.go#L25
-func getPathAndFilename(filename, id string, version int) (string, string) {
+func GetPathAndFilename(filename, id string, version int) (string, string) {
 	return fmt.Sprintf("%s/%s/version-%d", uploadRootDirectory, id, version), filename
 }


### PR DESCRIPTION
Effectively just reverting back to original code: https://github.com/ONSdigital/dp-interactives-importer/blob/573ad21182227b9bf9d03105ccfcb1c583562924/importer/handler.go#L92

Added a crufty test but better than nothing maybe? 😬 