### PR TITLE
Add collection_id to dp-upload-service request

### DIFF
--- a/features/consuming_interactive_upload_events.feature
+++ b/features/consuming_interactive_upload_events.feature
@@ -1,5 +1,12 @@
 Feature: Consuming messages from Kafka
 
+  Scenario: dp-interactives-api has sent a message with an invalid interactive id
+    Given these events are consumed:
+      | ID        | Path                         |
+      | invalid-1 | test_zips/does_not_exist.zip |
+    Then "0" interactives should be uploaded via the upload service
+    And "invalid-1" interactive should be updated as a failure via the interactives API
+
   Scenario: dp-interactives-api has sent a message with a non-existent zip file
     Given these events are consumed:
       | ID      | Path                     |

--- a/features/steps/component.go
+++ b/features/steps/component.go
@@ -101,6 +101,13 @@ func NewInteractivesImporterComponent() (*Component, error) {
 	}
 
 	c.InteractivesAPI = &mocks_importer.InteractivesAPIClientMock{
+		GetInteractiveFunc: func(contextMoqParam context.Context, s1 string, s2 string, s3 string) (interactives.Interactive, error) {
+			if s3 == "valid-1" {
+				return interactives.Interactive{ID: s3, Metadata: &interactives.Metadata{CollectionID: "collection-id"}}, nil
+			} else {
+				return interactives.Interactive{}, nil
+			}
+		},
 		PatchInteractiveFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, interactiveID string, req interactives.PatchRequest) (interactives.Interactive, error) {
 			return interactives.Interactive{}, nil
 		},

--- a/importer/archive.go
+++ b/importer/archive.go
@@ -28,12 +28,14 @@ var (
 type matcher func(string, string) bool
 
 type File struct {
-	Context     context.Context
-	ReadCloser  io.ReadCloser
-	Name        string
-	MimeType    string
-	SizeInBytes int64
-	Closed      bool
+	Context      context.Context
+	ReadCloser   io.ReadCloser
+	Name         string
+	MimeType     string
+	SizeInBytes  int64
+	Closed       bool
+	CollectionID string
+	RootPath     string
 }
 
 type batch struct {

--- a/importer/interface.go
+++ b/importer/interface.go
@@ -23,6 +23,7 @@ type UploadServiceBackend interface {
 }
 
 type InteractivesAPIClient interface {
+	GetInteractive(context.Context, string, string, string) (interactives.Interactive, error)
 	PatchInteractive(context.Context, string, string, string, interactives.PatchRequest) (interactives.Interactive, error)
 	Checker(ctx context.Context, state *health.CheckState) error
 }

--- a/importer/mocks/interactives_api.go
+++ b/importer/mocks/interactives_api.go
@@ -24,6 +24,9 @@ var _ importer.InteractivesAPIClient = &InteractivesAPIClientMock{}
 // 			CheckerFunc: func(ctx context.Context, state *health.CheckState) error {
 // 				panic("mock out the Checker method")
 // 			},
+// 			GetInteractiveFunc: func(contextMoqParam context.Context, s1 string, s2 string, s3 string) (interactives.Interactive, error) {
+// 				panic("mock out the GetInteractive method")
+// 			},
 // 			PatchInteractiveFunc: func(contextMoqParam context.Context, s1 string, s2 string, s3 string, patchRequest interactives.PatchRequest) (interactives.Interactive, error) {
 // 				panic("mock out the PatchInteractive method")
 // 			},
@@ -37,6 +40,9 @@ type InteractivesAPIClientMock struct {
 	// CheckerFunc mocks the Checker method.
 	CheckerFunc func(ctx context.Context, state *health.CheckState) error
 
+	// GetInteractiveFunc mocks the GetInteractive method.
+	GetInteractiveFunc func(contextMoqParam context.Context, s1 string, s2 string, s3 string) (interactives.Interactive, error)
+
 	// PatchInteractiveFunc mocks the PatchInteractive method.
 	PatchInteractiveFunc func(contextMoqParam context.Context, s1 string, s2 string, s3 string, patchRequest interactives.PatchRequest) (interactives.Interactive, error)
 
@@ -48,6 +54,17 @@ type InteractivesAPIClientMock struct {
 			Ctx context.Context
 			// State is the state argument value.
 			State *health.CheckState
+		}
+		// GetInteractive holds details about calls to the GetInteractive method.
+		GetInteractive []struct {
+			// ContextMoqParam is the contextMoqParam argument value.
+			ContextMoqParam context.Context
+			// S1 is the s1 argument value.
+			S1 string
+			// S2 is the s2 argument value.
+			S2 string
+			// S3 is the s3 argument value.
+			S3 string
 		}
 		// PatchInteractive holds details about calls to the PatchInteractive method.
 		PatchInteractive []struct {
@@ -64,6 +81,7 @@ type InteractivesAPIClientMock struct {
 		}
 	}
 	lockChecker          sync.RWMutex
+	lockGetInteractive   sync.RWMutex
 	lockPatchInteractive sync.RWMutex
 }
 
@@ -99,6 +117,49 @@ func (mock *InteractivesAPIClientMock) CheckerCalls() []struct {
 	mock.lockChecker.RLock()
 	calls = mock.calls.Checker
 	mock.lockChecker.RUnlock()
+	return calls
+}
+
+// GetInteractive calls GetInteractiveFunc.
+func (mock *InteractivesAPIClientMock) GetInteractive(contextMoqParam context.Context, s1 string, s2 string, s3 string) (interactives.Interactive, error) {
+	if mock.GetInteractiveFunc == nil {
+		panic("InteractivesAPIClientMock.GetInteractiveFunc: method is nil but InteractivesAPIClient.GetInteractive was just called")
+	}
+	callInfo := struct {
+		ContextMoqParam context.Context
+		S1              string
+		S2              string
+		S3              string
+	}{
+		ContextMoqParam: contextMoqParam,
+		S1:              s1,
+		S2:              s2,
+		S3:              s3,
+	}
+	mock.lockGetInteractive.Lock()
+	mock.calls.GetInteractive = append(mock.calls.GetInteractive, callInfo)
+	mock.lockGetInteractive.Unlock()
+	return mock.GetInteractiveFunc(contextMoqParam, s1, s2, s3)
+}
+
+// GetInteractiveCalls gets all the calls that were made to GetInteractive.
+// Check the length with:
+//     len(mockedInteractivesAPIClient.GetInteractiveCalls())
+func (mock *InteractivesAPIClientMock) GetInteractiveCalls() []struct {
+	ContextMoqParam context.Context
+	S1              string
+	S2              string
+	S3              string
+} {
+	var calls []struct {
+		ContextMoqParam context.Context
+		S1              string
+		S2              string
+		S3              string
+	}
+	mock.lockGetInteractive.RLock()
+	calls = mock.calls.GetInteractive
+	mock.lockGetInteractive.RUnlock()
 	return calls
 }
 

--- a/importer/upload.go
+++ b/importer/upload.go
@@ -23,9 +23,9 @@ type UploadService struct {
 	backend UploadServiceBackend
 }
 
-func (s *UploadService) SendFile(ctx context.Context, event *InteractivesUploaded, f *File, uploadRootPath string) (string, error) {
+func (s *UploadService) SendFile(ctx context.Context, event *InteractivesUploaded, f *File) (string, error) {
 	metadata := upload.Metadata{
-		Path:          uploadRootPath,
+		Path:          f.RootPath,
 		IsPublishable: true,
 		Title:         event.Title,
 		FileSizeBytes: f.SizeInBytes,
@@ -33,6 +33,7 @@ func (s *UploadService) SendFile(ctx context.Context, event *InteractivesUploade
 		License:       licenseName,
 		LicenseURL:    licenseURL,
 		FileName:      f.Name,
+		CollectionID:  &f.CollectionID,
 	}
 
 	err := s.backend.Upload(ctx, f.ReadCloser, metadata)

--- a/importer/upload_test.go
+++ b/importer/upload_test.go
@@ -30,6 +30,7 @@ func TestUploadService(t *testing.T) {
 			Name:        filename,
 			ReadCloser:  ioutil.NopCloser(strings.NewReader(testContent)),
 			SizeInBytes: size,
+			RootPath:    rootPath,
 		}
 
 		Convey("And a healthy upload service backend", func() {
@@ -41,14 +42,14 @@ func TestUploadService(t *testing.T) {
 			svc := importer.NewUploadService(mockBackend)
 
 			Convey("Then there should be no error when we send the file", func() {
-				f, err := svc.SendFile(context.TODO(), getTestEvent(filename), f, rootPath)
+				f, err := svc.SendFile(context.TODO(), getTestEvent(filename), f)
 
 				So(err, ShouldBeNil)
 				So(f, ShouldEqual, rootPath+"/root/dir/testing.css")
 			})
 
 			Convey("Then there should be no error when we send the file and the event has some existing files", func() {
-				f, err := svc.SendFile(context.TODO(), getTestEvent(filename, "/interactives/id/version-2/root/dir/testing.css"), f, rootPath)
+				f, err := svc.SendFile(context.TODO(), getTestEvent(filename, "/interactives/id/version-2/root/dir/testing.css"), f)
 
 				So(err, ShouldBeNil)
 				So(f, ShouldEqual, rootPath+"/root/dir/testing.css")
@@ -56,7 +57,7 @@ func TestUploadService(t *testing.T) {
 			})
 
 			Convey("Then there should be no error when we send the file and the event has some existing files without versioned path", func() {
-				f, err := svc.SendFile(context.TODO(), getTestEvent(filename, "/interactives/id/root/dir/testing.css"), f, rootPath)
+				f, err := svc.SendFile(context.TODO(), getTestEvent(filename, "/interactives/id/root/dir/testing.css"), f)
 
 				So(err, ShouldBeNil)
 				So(f, ShouldEqual, rootPath+"/root/dir/testing.css")
@@ -73,7 +74,7 @@ func TestUploadService(t *testing.T) {
 			svc := importer.NewUploadService(mockBackend)
 
 			Convey("Then there should be an expected error when we send the file", func() {
-				f, err := svc.SendFile(context.TODO(), getTestEvent(filename), f, rootPath)
+				f, err := svc.SendFile(context.TODO(), getTestEvent(filename), f)
 
 				So(err, ShouldNotBeNil)
 				So(f, ShouldBeEmpty)


### PR DESCRIPTION
### What

Bug where interactives is not associating collection_id to static files resources - this will break publishing flow. https://trello.com/c/mXiE1LMl/1190-interactives-downstream-files-not-associated-to-collection-as-expected

### How to review

👀 

### Who can review

👨‍💻 
